### PR TITLE
Save commits without Process Metrics - #22

### DIFF
--- a/data-collection/src/main/java/refactoringml/App.java
+++ b/data-collection/src/main/java/refactoringml/App.java
@@ -142,7 +142,6 @@ public class App {
 				commitIdToProcess = null;
 
 				// we define a timeout of 20 seconds for RefactoringMiner to find a refactoring.
-				//TODO: make the timeout a config setting, thus we could change it easily e.g. for testing
 				miner.detectAtCommit(repo, commitHash, handler, 20);
 
 				// if timeout has happened, refactoringsToProcess and commitIdToProcess will be null

--- a/data-collection/src/main/java/refactoringml/App.java
+++ b/data-collection/src/main/java/refactoringml/App.java
@@ -142,6 +142,7 @@ public class App {
 				commitIdToProcess = null;
 
 				// we define a timeout of 20 seconds for RefactoringMiner to find a refactoring.
+				//TODO: make the timeout a config setting, thus we could change it easily e.g. for testing
 				miner.detectAtCommit(repo, commitHash, handler, 20);
 
 				// if timeout has happened, refactoringsToProcess and commitIdToProcess will be null

--- a/data-collection/src/main/java/refactoringml/ProcessMetricsCollector.java
+++ b/data-collection/src/main/java/refactoringml/ProcessMetricsCollector.java
@@ -89,10 +89,10 @@ public class ProcessMetricsCollector {
 					try {
 						db.openSession();
 						refactoredClasses = collectProcessMetricsOfRefactoredCommit(commit);
+						db.commit();
 					} catch (Exception e) {
 						log.error("Error when collecting process metrics in commit " + commit.getName(), e);
 					} finally {
-						db.commit();
 						db.close();
 					}
 				}
@@ -105,10 +105,10 @@ public class ProcessMetricsCollector {
 				try {
 					db.openSession();
 					updateAndPrintExamplesOfNonRefactoredClasses(commit, refactoredClasses);
+					db.commit();
 				} catch (Exception e) {
 					log.error("Error when collecting process metrics in commit " + commit.getName(), e);
 				} finally {
-					db.commit();
 					db.close();
 				}
 			}

--- a/data-collection/src/main/java/refactoringml/db/ProcessMetrics.java
+++ b/data-collection/src/main/java/refactoringml/db/ProcessMetrics.java
@@ -6,6 +6,8 @@ import javax.persistence.Embeddable;
 @Embeddable
 public class ProcessMetrics {
 
+
+	@Column(nullable = true) private boolean processMetricsAvailable;
 	@Column(nullable = true) private int qtyOfCommits;
 	@Column(nullable = true) private int linesAdded;
 	@Column(nullable = true) private int linesDeleted;
@@ -19,8 +21,10 @@ public class ProcessMetrics {
 	@Deprecated // hibernate purposes
 	public ProcessMetrics() {}
 
-	public ProcessMetrics(int qtyOfCommits, int linesAdded, int linesDeleted, int qtyOfAuthors, long qtyMinorAuthors,
-	                      long qtyMajorAuthors, double authorOwnership, int bugFixCount, int refactoringsInvolved) {
+	public ProcessMetrics(boolean processMetricsAvailable, int qtyOfCommits, int linesAdded, int linesDeleted, int qtyOfAuthors, long qtyMinorAuthors,
+						  long qtyMajorAuthors, double authorOwnership, int bugFixCount, int refactoringsInvolved) {
+		this.refactoringsInvolved = refactoringsInvolved;
+		this.processMetricsAvailable = processMetricsAvailable;
 		this.qtyOfCommits = qtyOfCommits;
 		this.linesAdded = linesAdded;
 		this.linesDeleted = linesDeleted;
@@ -29,12 +33,12 @@ public class ProcessMetrics {
 		this.qtyMajorAuthors = qtyMajorAuthors;
 		this.authorOwnership = authorOwnership;
 		this.bugFixCount = bugFixCount;
-		this.refactoringsInvolved = refactoringsInvolved;
 	}
 
 	@Override
 	public String toString() {
 		return "ProcessMetrics{" +
+				"processMetricsAvailable=" + processMetricsAvailable +
 				"qtyOfCommits=" + qtyOfCommits +
 				", linesAdded=" + linesAdded +
 				", linesDeleted=" + linesDeleted +
@@ -46,6 +50,8 @@ public class ProcessMetrics {
 				", refactoringsInvolved=" + refactoringsInvolved +
 				'}';
 	}
+
+	public boolean hasProcessMetrics() { return processMetricsAvailable; }
 
 	public int getQtyOfCommits() {
 		return qtyOfCommits;

--- a/data-collection/src/main/java/refactoringml/db/Yes.java
+++ b/data-collection/src/main/java/refactoringml/db/Yes.java
@@ -1,5 +1,6 @@
 package refactoringml.db;
 
+import refactoringml.ProcessMetric;
 import refactoringml.util.RefactoringUtils;
 
 import javax.persistence.*;
@@ -89,6 +90,8 @@ public class Yes {
 	public MethodMetric getMethodMetrics() {
 		return methodMetrics;
 	}
+
+	public ProcessMetrics getProcessMetrics() { return processMetrics; }
 
 	public VariableMetric getVariableMetrics() {
 		return variableMetrics;

--- a/data-collection/src/test/java/integration/toyprojects/R1ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R1ToyProjectTest.java
@@ -49,5 +49,18 @@ public class R1ToyProjectTest extends IntegrationBaseTest {
 		Assert.assertEquals(0, project.getNumberOfTestFiles());
 
 		Assert.assertEquals(9, project.getProductionLoc());
+
 	}
+
+	@Test
+	public void processMetricsAvailable() {
+		List<Yes> yesList = session.createQuery("From Yes where project = :project order by refactoringDate desc")
+				.setParameter("project", project)
+				.list();
+
+		for (Yes element : yesList) {
+			Assert.assertFalse(element.getProcessMetrics().hasProcessMetrics());
+		}
+	}
+
 }

--- a/data-collection/src/test/java/integration/toyprojects/R2ToyProjectTest.java
+++ b/data-collection/src/test/java/integration/toyprojects/R2ToyProjectTest.java
@@ -55,4 +55,15 @@ public class R2ToyProjectTest extends IntegrationBaseTest {
 		Assert.assertEquals(56, project.getProductionLoc());
 
 	}
+
+	@Test
+	public void processMetricsAvailable() {
+		List<Yes> yesList = session.createQuery("From Yes where project = :project order by refactoringDate desc")
+				.setParameter("project", project)
+				.list();
+
+		for (Yes element : yesList) {
+			Assert.assertFalse(element.getProcessMetrics().hasProcessMetrics());
+		}
+	}
 }


### PR DESCRIPTION
 *  Save commits without process metrics
 *  Added processMetricsAvailable as a boolean colummn to Yes and No tables
 *  Implemented tests for test repos r1 and r2 to test process metrics availability